### PR TITLE
fix all commands having no auth

### DIFF
--- a/addon.txt
+++ b/addon.txt
@@ -1,8 +1,8 @@
 "AddonInfo"
 {
 	"name"            "TebexGmod"
-	"version"         "0.2"
-	"up_date"         "20/08/2018"
+	"version"         "0.3"
+	"up_date"         "13/08/2022"
 	"author_name"     "Tebex"
 	"author_email"    "liam@tebex.co.uk"
 	"author_url"      "https://www.tebex.io/"

--- a/lua/tebex/commands/forcecheck.lua
+++ b/lua/tebex/commands/forcecheck.lua
@@ -1,7 +1,7 @@
 Msg( "// Command tebex:forcecheck  //\n" )
 
 
-Tebex.commands["forcecheck"] = function(ply, args)
+Tebex.commands["forcecheck"] = function(args)
     Tebex.warn("Checking for commands to be executed...");
     apiclient = TebexApiClient:init(config:get("baseUrl"), config:get("secret"))
     apiclient:get("/queue", function(response)

--- a/lua/tebex/commands/info.lua
+++ b/lua/tebex/commands/info.lua
@@ -1,7 +1,7 @@
 Msg( "// Command tebex:info        //\n" )
 
 
-Tebex.commands["info"] = function(ply, args)
+Tebex.commands["info"] = function(args)
     apiclient = TebexApiClient:init(config:get("baseUrl"), config:get("secret"))
     apiclient:get("/information", function(response)
         TebexInformation.id = response["account"]["id"]

--- a/lua/tebex/commands/secret.lua
+++ b/lua/tebex/commands/secret.lua
@@ -1,7 +1,7 @@
 Msg( "// Command tebex:secret      //\n" )
 
 
-Tebex.commands["secret"] = function(ply, args)
+Tebex.commands["secret"] = function(args)
     if (args[3] == nil) then
         Tebex.err( "No secret provided" )
     end

--- a/lua/tebex/init.lua
+++ b/lua/tebex/init.lua
@@ -22,7 +22,7 @@ if not Tebex then
 	file.CreateDir( "tebex" )
 
 	Msg( "\n///////////////////////////////\n" )
-	Msg( "//      TebexGmod v 0.2      //\n" )
+	Msg( "//      TebexGmod v 0.3      //\n" )
 	Msg( "//   https://www.tebex.io/   //\n" )
 	Msg( "///////////////////////////////\n" )
 	Msg( "// Loading...                //\n" )

--- a/lua/tebex/init.lua
+++ b/lua/tebex/init.lua
@@ -42,6 +42,8 @@ if not Tebex then
 	config = TebexConfig:init()
 
 	concommand.Add("tebex", function(ply, cmd, args)
+		 -- Only allow commands directly from the server
+		if (IsValid(ply)) then return end
 
 		if (args[2] == nil) then
 			--Help!

--- a/lua/tebex/init.lua
+++ b/lua/tebex/init.lua
@@ -53,7 +53,7 @@ if not Tebex then
 			return
 		end
 
-		Tebex.commands[args[2]](ply,args);
+		Tebex.commands[args[2]](args);
 
 	end)
 


### PR DESCRIPTION
Currently, all commands have no auth. Meaning players can run any command, including changing the secret key.

This pull request makes it so all commands can only be run through the server console directly. I don't see any reason a command for this system would need to be player ran.
It also drops the useless player argument for commands.