### PR TITLE
Prevent concommand injections from being executed

### DIFF
--- a/lua/tebex/models/commandrunner.lua
+++ b/lua/tebex/models/commandrunner.lua
@@ -12,9 +12,15 @@ TebexCommandRunner.doOfflineCommands = function()
 
         for key,cmd in pairs(commands) do
             commandToRun = TebexCommandRunner.buildCommand(cmd["command"], cmd["player"]["name"], cmd["player"]["uuid"], cmd["player"]["meta"]["steamID"]);
+            commandToRun = commandToRun:Trim()
+
+            -- Prevent escaping console commands
+            if (commandToRun:find(";")) then
+                continue
+            end
 
             Tebex.warn("Run command " .. commandToRun)
-            game.ConsoleCommand( commandToRun )
+            RunConsoleCommand(unpack(string.Explode(" ", commandToRun)))
 
             table.insert(executedCommands, cmd["id"])
             exCount = exCount + 1
@@ -47,9 +53,15 @@ TebexCommandRunner.doOnlineCommands = function(playerPluginId, playerName, playe
 
         for key,cmd in pairs(commands) do
             commandToRun = TebexCommandRunner.buildCommand(cmd["command"], playerName, playerId, response.player.meta.steamID)
+            commandToRun = commandToRun:Trim()
+
+            -- Prevent escaping console commands
+            if (commandToRun:find(";")) then
+                continue
+            end
 
             Tebex.warn("Run command " .. commandToRun)
-            game.ConsoleCommand( commandToRun )
+            RunConsoleCommand(unpack(string.Explode(" ", commandToRun)))
 
             table.insert(executedCommands, cmd["id"])
             exCount = exCount + 1
@@ -79,7 +91,7 @@ TebexCommandRunner.buildCommand = function(cmd, username, id, steamid)
     cmd = cmd:gsub("{username}", username);
     cmd = cmd:gsub("{steamid}", steamid);
 
-    return cmd .. "\n";
+    return cmd;
 end
 
 TebexCommandRunner.deleteCommands = function(commandIds)


### PR DESCRIPTION
Hello,

Recently, I have been contacted by 3 server owners that were attacked and they all had in common that they had installed this Tebex package on their Garry's Mod server.
After a quick analysis, I realized that the **game.ConsoleCommand** was at the origin of the exploit used by the hackers.

### What is the exploit?
Let's imagine that a package is added and executes this command at each purchase:
```lua
ulx tsay "Thank you {username} for purchasing a package from our store!"
```
This command is then sent to the server and here is what is executed :
```lua
game.ConsoleCommand(commandToRun)
```

But as you can see on the Garry's Mod wiki :
![image](https://user-images.githubusercontent.com/72105771/188522898-56448138-9ad6-466c-83f6-6154011d47ee.png)

All you need to do so is changing your username to something like:
```lua
; fadmin setaccess your_name superadmin;
```
![image](https://user-images.githubusercontent.com/72105771/188701831-cb9fd5b6-1437-4f93-8646-4c4260b8f9a0.png)
![image](https://user-images.githubusercontent.com/72105771/188701877-b64476d0-db25-4d8a-bd5a-61bbcb7786ca.png)
and here we go, we just did a successfully "concommand" injection **that will give superadmin access to the player**.

I think you should also think about other ways to prevent arbitrary code execution since you send the username in a server command so any kind of injection is possible since nothing is controlled (as far as I know).

### Impacts
We have a full access to the server console and here are some bad things I can think of right now:
- Delete the entire database of a server
- Use the 'file' library to read all addon files and send everything to a basic HTTP server to filesteal all the server (and sell it or blackmailing...)
- Inject a simple backdoor code into the server to gain access forever
- Run command on every client connected - even administrators - to get private data.
- Get the Tebex secret key (I think I don't need to explain what it can do)
- and so on...

### What about the fix?
This PR does change a few lines in order to:
- Trim the command to prevent arbitrary '\n' from the command
- Prevent any command containing a ';' from being executed
- Use RunConsoleCommand instead of game.ConsoleCommand as recommended by the Garry's Mod wiki

This is the most generic fix I can think of. If you don't like the idea, you can also simply secure the player name you are using to replace ``{username}`` in the command string.
![image](https://user-images.githubusercontent.com/72105771/188524130-2d82955c-8128-4dad-acbc-05d3ea8822fc.png)
